### PR TITLE
Fix escapeHtml handling for falsy values

### DIFF
--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -7,8 +7,8 @@
  * @returns {string} - HTML-escaped text
  */
 export function escapeHtml(text) {
-    if (!text) return '';
-    
+    if (text === null || text === undefined) return '';
+
     const map = {
         '&': '&amp;',
         '<': '&lt;',

--- a/tests/frontend_tests/test_formatters_escape.py
+++ b/tests/frontend_tests/test_formatters_escape.py
@@ -1,0 +1,43 @@
+"""Tests for frontend escapeHtml utility using Node.js ES module import."""
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+
+class TestEscapeHtml(unittest.TestCase):
+    """Verify escapeHtml handles falsy values without losing data."""
+
+    def test_escape_html_preserves_falsy_values(self):
+        project_root = Path(__file__).resolve().parents[2]
+        formatter_path = project_root / 'frontend' / 'src' / 'utils' / 'formatters.js'
+
+        script = f"""
+import {{ escapeHtml }} from 'file://{formatter_path}';
+const results = [
+  escapeHtml(0),
+  escapeHtml(false),
+  escapeHtml(''),
+  escapeHtml(null),
+  escapeHtml(undefined)
+];
+console.log(JSON.stringify(results));
+"""
+
+        completed = subprocess.run(
+            ['node', '--input-type=module', '-e', script],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        outputs = json.loads(completed.stdout.strip())
+        self.assertEqual(outputs[0], '0')
+        self.assertEqual(outputs[1], 'false')
+        self.assertEqual(outputs[2], '')
+        self.assertEqual(outputs[3], '')
+        self.assertEqual(outputs[4], '')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure escapeHtml preserves falsy but non-null values like 0 and false
- add a Node-backed frontend test covering escapeHtml falsy handling

## Testing
- python -m unittest discover -s tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d7b632974832fb7a1054b7dcac1b7)