### PR TITLE
Ensure integration workflow uses mock data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,13 +189,15 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-    
+
     - name: Test server startup
+      env:
+        USE_MOCK_DATA: "true"
       run: |
         echo "Testing server startup (without API token)..."
         # Start server in background
@@ -216,8 +218,10 @@ jobs:
         # Stop server
         kill $SERVER_PID 2>/dev/null || true
         wait $SERVER_PID 2>/dev/null || true
-    
+
     - name: Test API endpoints respond
+      env:
+        USE_MOCK_DATA: "true"
       run: |
         echo "Testing API endpoints..."
         # Start server in background


### PR DESCRIPTION
## Summary
- run integration job steps with mock data enabled to avoid API token requirements during CI
- allow endpoint checks to exercise the server using bundled mock data

## Testing
- python -m py_compile backend/app.py
- python -m unittest discover -s tests -p "test_*.py"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d7d0e0d58832fa4e03dee5ce803c2)