### PR TITLE
Handle mock data load failures with non-zero exit

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1130,7 +1130,7 @@ def main():
         mock_data = load_mock_data(MOCK_SCENARIO)
         if mock_data is None:
             logger.error("Failed to load mock data. Exiting.")
-            return
+            return 1
         
         # Initialize STATE with mock data
         # Use services from mock data if present, otherwise empty list

--- a/tests/backend_tests/test_config_validation.py
+++ b/tests/backend_tests/test_config_validation.py
@@ -353,10 +353,35 @@ class TestMainWithValidation(unittest.TestCase):
                 'per_page': 100,
                 'mock_scenario': ''
             }
-            
+
             result = server.main()
             self.assertEqual(result, 1)
-    
+
+    def test_main_exits_with_nonzero_when_mock_data_missing(self):
+        """Test that main() returns nonzero when mock data fails to load"""
+        config = {
+            'use_mock_data': True,
+            'api_token': '',
+            'poll_interval_sec': 60,
+            'cache_ttl_sec': 300,
+            'per_page': 100,
+            'mock_scenario': '',
+            'port': 8080,
+            'gitlab_url': 'https://gitlab.com',
+            'insecure_skip_verify': False,
+            'ca_bundle_path': None,
+            'group_ids': [],
+            'project_ids': []
+        }
+
+        with patch.object(server, 'load_config', return_value=config), \
+                patch.object(server, 'load_mock_data', return_value=None), \
+                patch.object(server, 'DashboardServer') as mock_server:
+            result = server.main()
+
+        self.assertEqual(result, 1)
+        mock_server.assert_not_called()
+
     def test_main_continues_on_valid_config(self):
         """Test that main() continues past validation when config is valid"""
         mock_data = {


### PR DESCRIPTION
## Summary
- return a non-zero exit code when mock data fails to load in mock mode
- add regression coverage for mock data load failures to main() validation tests

## Testing
- python -m unittest discover -s tests -p "test_*.py"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d7ea58d70832f8f5baf0a42cd9d98)